### PR TITLE
feat: add personal os web app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# chat-gpt
-It can do what ever it wants here 
+# Personal OS (Student–Creator Edition)
+
+A lightweight modular web app that runs entirely in the browser. Open `index.html` locally or host the folder on any static host.
+
+## Quick Start
+1. Download the project ZIP and unzip.
+2. Open `index.html` in your browser.
+3. Use the navigation or press `Cmd/Ctrl+K` for the command palette.
+
+## Optional AI Setup
+1. Open the Settings module.
+2. Choose a backend (Mock, DeepSeek, OpenRouter).
+3. Paste your API key and save. Keys are stored locally.
+
+## Deployment
+- Upload the folder to GitHub Pages, Netlify, or Vercel as a static site.
+
+## Troubleshooting
+- If assets fail to load after updates, clear the service worker cache or bump the `CACHE` value in `sw.js`.
+- To reset data, clear browser storage for this site.
+
+## Privacy
+All data and keys stay in your browser. No information is sent to a server unless you configure an AI backend.

--- a/ai/adapter.js
+++ b/ai/adapter.js
@@ -1,0 +1,12 @@
+import * as mock from './backends/mock.js';
+import * as deepseek from './backends/deepseek.js';
+import * as openrouter from './backends/openrouter.js';
+import { store } from '../app.js';
+
+const backends = { mock, deepseek, openrouter };
+
+export async function complete(opts){
+  const cfg = store.get('ai', {backend:'mock', keys:{}});
+  const backend = backends[cfg.backend] || mock;
+  return backend.complete(opts, cfg);
+}

--- a/ai/backends/deepseek.js
+++ b/ai/backends/deepseek.js
@@ -1,0 +1,19 @@
+export async function complete(opts,cfg){
+  const key = cfg.keys?.deepseek;
+  if(!key) return {error:'No DeepSeek key'};
+  try{
+    const res = await fetch((cfg.baseUrl||'https://api.deepseek.com/v1/complete'),{
+      method:'POST',
+      headers:{'Content-Type':'application/json','Authorization':`Bearer ${key}`},
+      body: JSON.stringify({
+        model: cfg.model||'deepseek-chat',
+        prompt: opts.messages.map(m=>m.content).join('\n'),
+        max_tokens: opts.maxTokens||200
+      })
+    });
+    const json = await res.json();
+    return {text: json.choices?.[0]?.text||''};
+  }catch(e){
+    return {error:e.message};
+  }
+}

--- a/ai/backends/mock.js
+++ b/ai/backends/mock.js
@@ -1,0 +1,5 @@
+export async function complete({task, system, messages}){
+  // simple mock: echo last user message
+  const last = messages && messages.length ? messages[messages.length-1].content : '';
+  return {text: `Mock response for ${task}: ${last}`};
+}

--- a/ai/backends/openrouter.js
+++ b/ai/backends/openrouter.js
@@ -1,0 +1,19 @@
+export async function complete(opts,cfg){
+  const key = cfg.keys?.openrouter;
+  if(!key) return {error:'No OpenRouter key'};
+  try{
+    const res = await fetch((cfg.baseUrl||'https://openrouter.ai/api/v1/chat/completions'),{
+      method:'POST',
+      headers:{'Content-Type':'application/json','Authorization':`Bearer ${key}`},
+      body: JSON.stringify({
+        model: cfg.model||'gpt-3.5-turbo',
+        messages: opts.messages,
+        max_tokens: opts.maxTokens||200
+      })
+    });
+    const json = await res.json();
+    return {text: json.choices?.[0]?.message?.content||''};
+  }catch(e){
+    return {error:e.message};
+  }
+}

--- a/app.js
+++ b/app.js
@@ -1,0 +1,140 @@
+// Basic storage wrappers
+export const db = {
+  async get(store, key) {
+    return new Promise((res, rej) => {
+      const open = indexedDB.open('personalOS', 1);
+      open.onupgradeneeded = () => open.result.createObjectStore(store);
+      open.onsuccess = () => {
+        const tx = open.result.transaction(store, 'readonly');
+        const req = tx.objectStore(store).get(key);
+        req.onsuccess = () => res(req.result);
+        req.onerror = rej;
+      };
+      open.onerror = rej;
+    });
+  },
+  async set(store, key, val) {
+    return new Promise((res, rej) => {
+      const open = indexedDB.open('personalOS', 1);
+      open.onupgradeneeded = () => open.result.createObjectStore(store);
+      open.onsuccess = () => {
+        const tx = open.result.transaction(store, 'readwrite');
+        tx.objectStore(store).put(val, key);
+        tx.oncomplete = res;
+        tx.onerror = rej;
+      };
+      open.onerror = rej;
+    });
+  }
+};
+
+export const store = {
+  get: (k, d) => JSON.parse(localStorage.getItem(k) || JSON.stringify(d)),
+  set: (k, v) => localStorage.setItem(k, JSON.stringify(v))
+};
+
+// Theme
+const themeToggle = document.getElementById('themeToggle');
+const currentTheme = store.get('theme', 'light');
+if (currentTheme === 'dark') document.documentElement.dataset.theme = 'dark';
+
+themeToggle.onclick = () => {
+  const t = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+  if (t === 'dark') document.documentElement.dataset.theme = 'dark';
+  else delete document.documentElement.dataset.theme;
+  store.set('theme', t);
+};
+
+// Module loader
+const modules = ['tasks','study','creator','budget','focus','resume','skincare','fitness','college','media','portfolio','calendar','prompts','files','settings'];
+const nav = document.getElementById('nav');
+const palette = document.getElementById('palette');
+const paletteInput = document.getElementById('paletteInput');
+const paletteList = document.getElementById('paletteList');
+const view = document.getElementById('view');
+
+const loaded = {};
+const actions = [];
+
+async function initModules(){
+  for (const id of modules){
+    const manifest = await fetch(`modules/${id}/manifest.json`).then(r=>r.json());
+    if(!manifest.enabled) continue;
+    const link = document.createElement('a');
+    link.href = `#${id}`; link.textContent = manifest.name;
+    nav.appendChild(link);
+    actions.push({id, name: manifest.name});
+  }
+}
+
+async function loadModule(id){
+  const mod = await import(`./modules/${id}/module.js`);
+  const html = await fetch(`modules/${id}/view.html`).then(r=>r.text());
+  view.innerHTML = html;
+  if(mod.default) mod.default();
+  view.focus();
+}
+
+window.addEventListener('hashchange',()=>{
+  const id = location.hash.slice(1) || modules[0];
+  loadModule(id);
+});
+
+initModules().then(()=>{
+  const id = location.hash.slice(1) || modules[0];
+  if(location.hash==='') location.hash = id;
+  loadModule(id);
+});
+
+// Command palette
+function openPalette(){
+  palette.classList.remove('hidden');
+  paletteInput.value='';
+  paletteInput.focus();
+  renderPalette(actions);
+}
+function closePalette(){ palette.classList.add('hidden'); }
+
+function renderPalette(items){
+  paletteList.innerHTML='';
+  items.forEach(a=>{
+    const li=document.createElement('li');
+    li.textContent=a.name;
+    li.onclick=()=>{location.hash=a.id; closePalette();};
+    paletteList.appendChild(li);
+  });
+}
+
+paletteInput.oninput=()=>{
+  const q=paletteInput.value.toLowerCase();
+  renderPalette(actions.filter(a=>a.name.toLowerCase().includes(q)));
+};
+
+window.addEventListener('keydown',e=>{
+  if((e.metaKey||e.ctrlKey)&&e.key==='k'){e.preventDefault();openPalette();}
+  if(e.key==='Escape') closePalette();
+});
+
+// Notifications
+export function notify(msg){
+  if(Notification.permission==='granted') new Notification(msg);
+  else if(Notification.permission!=='denied') Notification.requestPermission();
+}
+
+// Data backup
+export async function exportData(){
+  const data={};
+  for(const storeName of ['tasks','habits','notes','budget','prompts']){
+    data[storeName]=await db.get(storeName,'all')||[];
+  }
+  const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='backup.json';
+  a.click();
+}
+
+// Service worker
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('sw.js');
+}

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#4e8cff" />
+</svg>

--- a/backup-example.json
+++ b/backup-example.json
@@ -1,0 +1,5 @@
+{
+  "tasks": [{"text": "Sample task", "done": false}],
+  "budget": [{"desc": "Sample income", "amt": 100}],
+  "prompts": ["Example prompt"]
+}

--- a/data/schema.md
+++ b/data/schema.md
@@ -1,0 +1,16 @@
+# Data Schema
+
+- **tasks**: `{ text: string, done: boolean }
+- **habits**: `{ name: string, streak: number }
+- **srCards**: `{ subject: string, topic: string, due: number }
+- **contentIdeas**: `{ title: string, platform: string }
+- **budgetTxns**: `{ desc: string, amt: number }
+- **focusNotes**: `string`
+- **resumeProfile**: `{ name: string, summary: string }
+- **skincareLogs**: `{ date: string, note: string, rating: number }
+- **workouts**: `{ name: string, reps: number }
+- **meals**: `{ name: string, calories: number }
+- **apps**: `{ school: string, status: string }
+- **essays**: `{ title: string, body: string }
+- **calendarEvents**: `{ title: string, date: string }
+- **prompts**: `string`

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal OS</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Personal OS</h1>
+    <nav id="nav"></nav>
+    <button id="themeToggle" aria-label="Toggle theme">🌓</button>
+  </header>
+  <main id="view" tabindex="-1"></main>
+
+  <!-- Command palette -->
+  <div id="palette" class="hidden" role="dialog" aria-modal="true">
+    <input id="paletteInput" type="text" placeholder="Type a command" aria-label="Command input" />
+    <ul id="paletteList"></ul>
+  </div>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/modules/budget/manifest.json
+++ b/modules/budget/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "budget",
+  "name": "Budget",
+  "enabled": true
+}

--- a/modules/budget/module.js
+++ b/modules/budget/module.js
@@ -1,0 +1,17 @@
+import { store } from '../../app.js';
+export default function(){
+  const form=document.getElementById('txnForm');
+  const desc=document.getElementById('txnDesc');
+  const amt=document.getElementById('txnAmt');
+  const list=document.getElementById('txnList');
+  const total=document.getElementById('budgetTotal');
+  let txns=store.get('budget',[{desc:'Sample income',amt:100}]);
+  function render(){
+    list.innerHTML='';
+    let sum=0;
+    txns.forEach((t,i)=>{sum+=Number(t.amt);const li=document.createElement('li');li.textContent=`${t.desc}: $${t.amt}`;list.appendChild(li);});
+    total.textContent='Total: $'+sum;
+  }
+  render();
+  form.onsubmit=e=>{e.preventDefault();txns.push({desc:desc.value,amt:amt.value});store.set('budget',txns);form.reset();render();};
+}

--- a/modules/budget/view.html
+++ b/modules/budget/view.html
@@ -1,0 +1,8 @@
+<h2>Budget</h2>
+<form id="txnForm">
+  <input id="txnDesc" placeholder="Description" required />
+  <input id="txnAmt" type="number" placeholder="Amount" required />
+  <button>Add</button>
+</form>
+<ul id="txnList"></ul>
+<p id="budgetTotal"></p>

--- a/modules/calendar/manifest.json
+++ b/modules/calendar/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "calendar",
+  "name": "Calendar",
+  "enabled": true
+}

--- a/modules/calendar/module.js
+++ b/modules/calendar/module.js
@@ -1,0 +1,9 @@
+import { store } from '../../app.js';
+export default function(){
+  const list=document.getElementById('calList');
+  const tasks=store.get('tasks',[]);
+  const apps=store.get('apps',[]);
+  list.innerHTML='';
+  tasks.forEach(t=>{const li=document.createElement('li');li.textContent=`Task: ${t.text}`;list.appendChild(li);});
+  apps.forEach(a=>{const li=document.createElement('li');li.textContent=`Application: ${a.school} (${a.status})`;list.appendChild(li);});
+}

--- a/modules/calendar/view.html
+++ b/modules/calendar/view.html
@@ -1,0 +1,2 @@
+<h2>Calendar</h2>
+<ul id="calList"></ul>

--- a/modules/college/manifest.json
+++ b/modules/college/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "college",
+  "name": "College Planner",
+  "enabled": true
+}

--- a/modules/college/module.js
+++ b/modules/college/module.js
@@ -1,0 +1,11 @@
+import { store } from '../../app.js';
+export default function(){
+  const form=document.getElementById('appForm');
+  const school=document.getElementById('appSchool');
+  const status=document.getElementById('appStatus');
+  const list=document.getElementById('appList');
+  let apps=store.get('apps',[{school:'Sample University',status:'Draft'}]);
+  function render(){list.innerHTML='';apps.forEach(a=>{const li=document.createElement('li');li.textContent=`${a.school} - ${a.status}`;list.appendChild(li);});}
+  render();
+  form.onsubmit=e=>{e.preventDefault();apps.push({school:school.value,status:status.value});store.set('apps',apps);form.reset();render();};
+}

--- a/modules/college/view.html
+++ b/modules/college/view.html
@@ -1,0 +1,7 @@
+<h2>Applications</h2>
+<form id="appForm">
+  <input id="appSchool" placeholder="School" required />
+  <input id="appStatus" placeholder="Status" />
+  <button>Add</button>
+</form>
+<ul id="appList"></ul>

--- a/modules/creator/manifest.json
+++ b/modules/creator/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "creator",
+  "name": "Creator Hub",
+  "enabled": true
+}

--- a/modules/creator/module.js
+++ b/modules/creator/module.js
@@ -1,0 +1,18 @@
+import { store } from '../../app.js';
+import { complete } from '../../ai/adapter.js';
+export default function(){
+  const list=document.getElementById('ideaList');
+  const form=document.getElementById('ideaForm');
+  const title=document.getElementById('ideaTitle');
+  const platform=document.getElementById('ideaPlatform');
+  const captionBtn=document.getElementById('captionBtn');
+  const captionOut=document.getElementById('captionOut');
+  let ideas=store.get('ideas',[{title:'Sample video',platform:'TikTok'}]);
+  function render(){list.innerHTML='';ideas.forEach(i=>{const li=document.createElement('li');li.textContent=`${i.title} (${i.platform})`;list.appendChild(li);});}
+  render();
+  form.onsubmit=e=>{e.preventDefault();ideas.push({title:title.value,platform:platform.value});store.set('ideas',ideas);render();form.reset();};
+  captionBtn.onclick=async()=>{
+    const res=await complete({task:'caption',messages:[{role:'user',content:title.value||'Give me a caption'}]});
+    captionOut.textContent=res.text||res.error;
+  };
+}

--- a/modules/creator/view.html
+++ b/modules/creator/view.html
@@ -1,0 +1,9 @@
+<h2>Content Ideas</h2>
+<form id="ideaForm">
+  <input id="ideaTitle" placeholder="Title" required />
+  <input id="ideaPlatform" placeholder="Platform" />
+  <button>Add</button>
+</form>
+<ul id="ideaList"></ul>
+<button id="captionBtn">Generate Caption</button>
+<p id="captionOut"></p>

--- a/modules/files/manifest.json
+++ b/modules/files/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "files",
+  "name": "File Tools",
+  "enabled": true
+}

--- a/modules/files/module.js
+++ b/modules/files/module.js
@@ -1,0 +1,11 @@
+export default function(){
+  const input=document.getElementById('fileInput');
+  const preview=document.getElementById('filePreview');
+  input.onchange=()=>{
+    const file=input.files[0];
+    if(!file) return;
+    const reader=new FileReader();
+    reader.onload=e=>{preview.textContent=e.target.result.slice(0,500);};
+    reader.readAsText(file);
+  };
+}

--- a/modules/files/view.html
+++ b/modules/files/view.html
@@ -1,0 +1,3 @@
+<h2>File Tools</h2>
+<input type="file" id="fileInput" multiple />
+<pre id="filePreview"></pre>

--- a/modules/fitness/manifest.json
+++ b/modules/fitness/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "fitness",
+  "name": "Fitness & Meals",
+  "enabled": true
+}

--- a/modules/fitness/module.js
+++ b/modules/fitness/module.js
@@ -1,0 +1,11 @@
+import { store } from '../../app.js';
+export default function(){
+  const form=document.getElementById('workForm');
+  const name=document.getElementById('workName');
+  const reps=document.getElementById('workReps');
+  const list=document.getElementById('workList');
+  let workouts=store.get('workouts',[{name:'Push Ups',reps:10}]);
+  function render(){list.innerHTML='';workouts.forEach(w=>{const li=document.createElement('li');li.textContent=`${w.name} - ${w.reps} reps`;list.appendChild(li);});}
+  render();
+  form.onsubmit=e=>{e.preventDefault();workouts.push({name:name.value,reps:reps.value});store.set('workouts',workouts);form.reset();render();};
+}

--- a/modules/fitness/view.html
+++ b/modules/fitness/view.html
@@ -1,0 +1,7 @@
+<h2>Workout Planner</h2>
+<form id="workForm">
+  <input id="workName" placeholder="Exercise" />
+  <input id="workReps" type="number" placeholder="Reps" />
+  <button>Add</button>
+</form>
+<ul id="workList"></ul>

--- a/modules/focus/manifest.json
+++ b/modules/focus/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "focus",
+  "name": "Focus Tools",
+  "enabled": true
+}

--- a/modules/focus/module.js
+++ b/modules/focus/module.js
@@ -1,0 +1,14 @@
+import { store } from '../../app.js';
+export default function(){
+  const display=document.getElementById('timerDisplay');
+  const start=document.getElementById('startPom');
+  const notes=document.getElementById('focusNotes');
+  const exportBtn=document.getElementById('exportNotes');
+  notes.value=store.get('focusNotes','');
+  let remaining=1500; let timer;
+  function render(){const m=Math.floor(remaining/60).toString().padStart(2,'0');const s=(remaining%60).toString().padStart(2,'0');display.textContent=`${m}:${s}`;}
+  render();
+  start.onclick=()=>{clearInterval(timer);timer=setInterval(()=>{if(--remaining<0){clearInterval(timer);alert('Done!');remaining=1500;}render();},1000);};
+  notes.oninput=()=>store.set('focusNotes',notes.value);
+  exportBtn.onclick=()=>{const blob=new Blob([notes.value],{type:'text/markdown'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='notes.md';a.click();};
+}

--- a/modules/focus/view.html
+++ b/modules/focus/view.html
@@ -1,0 +1,5 @@
+<h2>Pomodoro</h2>
+<p id="timerDisplay">25:00</p>
+<button id="startPom">Start</button>
+<textarea id="focusNotes" placeholder="Notes" rows="5"></textarea>
+<button id="exportNotes">Export Notes</button>

--- a/modules/media/manifest.json
+++ b/modules/media/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "media",
+  "name": "Media Tools",
+  "enabled": true
+}

--- a/modules/media/module.js
+++ b/modules/media/module.js
@@ -1,0 +1,6 @@
+export default function(){
+  const input=document.getElementById('srtInput');
+  const btn=document.getElementById('exportSrt');
+  input.value='1\n00:00:00,000 --> 00:00:02,000\nSample caption';
+  btn.onclick=()=>{const blob=new Blob([input.value],{type:'text/plain'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='captions.srt';a.click();};
+}

--- a/modules/media/view.html
+++ b/modules/media/view.html
@@ -1,0 +1,3 @@
+<h2>SRT Editor</h2>
+<textarea id="srtInput" rows="10" placeholder="Paste SRT here"></textarea>
+<button id="exportSrt">Export SRT</button>

--- a/modules/portfolio/manifest.json
+++ b/modules/portfolio/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "portfolio",
+  "name": "Portfolio Generator",
+  "enabled": true
+}

--- a/modules/portfolio/module.js
+++ b/modules/portfolio/module.js
@@ -1,0 +1,13 @@
+export default function(){
+  const form=document.getElementById('portForm');
+  const name=document.getElementById('portName');
+  const bio=document.getElementById('portBio');
+  const dl=document.getElementById('portDownload');
+  form.onsubmit=e=>{e.preventDefault();
+    const html=`<!DOCTYPE html><html><head><meta charset='utf-8'><title>${name.value}</title><style>body{font-family:sans-serif;padding:1rem;}</style></head><body><h1>${name.value}</h1><p>${bio.value}</p></body></html>`;
+    const blob=new Blob([html],{type:'text/html'});
+    dl.href=URL.createObjectURL(blob);
+    dl.download='portfolio.html';
+    dl.textContent='Download portfolio.html';
+  };
+}

--- a/modules/portfolio/view.html
+++ b/modules/portfolio/view.html
@@ -1,0 +1,7 @@
+<h2>Portfolio Builder</h2>
+<form id="portForm">
+  <input id="portName" placeholder="Your Name" />
+  <textarea id="portBio" placeholder="Bio"></textarea>
+  <button>Create</button>
+</form>
+<a id="portDownload"></a>

--- a/modules/prompts/manifest.json
+++ b/modules/prompts/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "prompts",
+  "name": "Prompt Library",
+  "enabled": true
+}

--- a/modules/prompts/module.js
+++ b/modules/prompts/module.js
@@ -1,0 +1,11 @@
+import { store } from '../../app.js';
+import { complete } from '../../ai/adapter.js';
+export default function(){
+  const form=document.getElementById('promptForm');
+  const text=document.getElementById('promptText');
+  const list=document.getElementById('promptList');
+  let prompts=store.get('prompts',['Example prompt']);
+  function render(){list.innerHTML='';prompts.forEach(p=>{const li=document.createElement('li');li.textContent=p;li.onclick=async()=>{const res=await complete({task:'test',messages:[{role:'user',content:p}]});alert(res.text||res.error);};list.appendChild(li);});}
+  render();
+  form.onsubmit=e=>{e.preventDefault();prompts.push(text.value);store.set('prompts',prompts);form.reset();render();};
+}

--- a/modules/prompts/view.html
+++ b/modules/prompts/view.html
@@ -1,0 +1,6 @@
+<h2>Prompts</h2>
+<form id="promptForm">
+  <input id="promptText" placeholder="Prompt" />
+  <button>Save</button>
+</form>
+<ul id="promptList"></ul>

--- a/modules/resume/manifest.json
+++ b/modules/resume/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "resume",
+  "name": "Resume Builder",
+  "enabled": true
+}

--- a/modules/resume/module.js
+++ b/modules/resume/module.js
@@ -1,0 +1,11 @@
+import { store } from '../../app.js';
+export default function(){
+  const form=document.getElementById('profileForm');
+  const name=document.getElementById('name');
+  const summary=document.getElementById('summary');
+  const exportBtn=document.getElementById('exportResume');
+  const prof=store.get('resume',{name:'Student',summary:'Aspiring professional'});
+  name.value=prof.name;summary.value=prof.summary;
+  form.onsubmit=e=>{e.preventDefault();store.set('resume',{name:name.value,summary:summary.value});alert('Saved');};
+  exportBtn.onclick=()=>{const blob=new Blob([JSON.stringify({name:name.value,summary:summary.value},null,2)],{type:'application/json'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='resume.json';a.click();};
+}

--- a/modules/resume/view.html
+++ b/modules/resume/view.html
@@ -1,0 +1,7 @@
+<h2>Resume Profile</h2>
+<form id="profileForm">
+  <input id="name" placeholder="Name" required />
+  <textarea id="summary" placeholder="Summary"></textarea>
+  <button>Save</button>
+</form>
+<button id="exportResume">Export JSON</button>

--- a/modules/settings/manifest.json
+++ b/modules/settings/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "settings",
+  "name": "Settings",
+  "enabled": true
+}

--- a/modules/settings/module.js
+++ b/modules/settings/module.js
@@ -1,0 +1,13 @@
+import { store } from '../../app.js';
+export default function(){
+  const backend=document.getElementById('aiBackend');
+  const deepseek=document.getElementById('deepseekKey');
+  const openrouter=document.getElementById('openrouterKey');
+  const save=document.getElementById('saveSettings');
+  const cfg=store.get('ai',{backend:'mock',keys:{}});
+  backend.value=cfg.backend;deepseek.value=cfg.keys.deepseek||'';openrouter.value=cfg.keys.openrouter||'';
+  save.onclick=()=>{
+    store.set('ai',{backend:backend.value,keys:{deepseek:deepseek.value,openrouter:openrouter.value}});
+    alert('Saved settings');
+  };
+}

--- a/modules/settings/view.html
+++ b/modules/settings/view.html
@@ -1,0 +1,11 @@
+<h2>Settings</h2>
+<label>AI Backend
+  <select id="aiBackend">
+    <option value="mock">Mock</option>
+    <option value="deepseek">DeepSeek</option>
+    <option value="openrouter">OpenRouter</option>
+  </select>
+</label>
+<label>DeepSeek Key <input id="deepseekKey" /></label>
+<label>OpenRouter Key <input id="openrouterKey" /></label>
+<button id="saveSettings">Save</button>

--- a/modules/skincare/manifest.json
+++ b/modules/skincare/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "skincare",
+  "name": "Skincare",
+  "enabled": true
+}

--- a/modules/skincare/module.js
+++ b/modules/skincare/module.js
@@ -1,0 +1,9 @@
+import { store } from '../../app.js';
+export default function(){
+  const form=document.getElementById('skinForm');
+  const list=document.getElementById('skinList');
+  let logs=store.get('skinLogs',[]);
+  function render(){list.innerHTML='';logs.forEach(l=>{const li=document.createElement('li');li.textContent=`${l.date}: ${l.note} (${l.rating}/10)`;list.appendChild(li);});}
+  render();
+  form.onsubmit=e=>{e.preventDefault();logs.push({date:skinDate.value,note:skinNote.value,rating:skinRating.value});store.set('skinLogs',logs);form.reset();render();};
+}

--- a/modules/skincare/view.html
+++ b/modules/skincare/view.html
@@ -1,0 +1,8 @@
+<h2>Skincare Log</h2>
+<form id="skinForm">
+  <input id="skinDate" type="date" />
+  <input id="skinNote" placeholder="Notes" />
+  <input id="skinRating" type="number" min="1" max="10" placeholder="Rating" />
+  <button>Add</button>
+</form>
+<ul id="skinList"></ul>

--- a/modules/study/manifest.json
+++ b/modules/study/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "study",
+  "name": "Study Planner",
+  "enabled": true
+}

--- a/modules/study/module.js
+++ b/modules/study/module.js
@@ -1,0 +1,23 @@
+import { store } from '../../app.js';
+export default function(){
+  const subjSel=document.getElementById('subjectSelect');
+  const cardList=document.getElementById('cardList');
+  const reviewBtn=document.getElementById('reviewBtn');
+  const data=store.get('study',{subjects:{
+    Chemistry:['Atoms','Bonds'],
+    Geometry:['Triangles'],
+    'Global History':['Renaissance']
+  }});
+  Object.keys(data.subjects).forEach(s=>{
+    const opt=document.createElement('option');opt.value=s;opt.textContent=s;subjSel.appendChild(opt);
+  });
+  function render(){
+    cardList.innerHTML='';
+    const subj=data.subjects[subjSel.value]||[];
+    subj.forEach(c=>{
+      const li=document.createElement('li');li.textContent=c;cardList.appendChild(li);
+    });
+  }
+  subjSel.onchange=render;render();
+  reviewBtn.onclick=()=>alert('Review session logged!');
+}

--- a/modules/study/view.html
+++ b/modules/study/view.html
@@ -1,0 +1,4 @@
+<h2>Study Planner</h2>
+<select id="subjectSelect"></select>
+<ul id="cardList"></ul>
+<button id="reviewBtn">Review Now</button>

--- a/modules/tasks/manifest.json
+++ b/modules/tasks/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "tasks",
+  "name": "Tasks & Habits",
+  "enabled": true
+}

--- a/modules/tasks/module.js
+++ b/modules/tasks/module.js
@@ -1,0 +1,21 @@
+import { store, notify } from '../../app.js';
+export default function(){
+  const list = document.getElementById('taskList');
+  const form = document.getElementById('taskForm');
+  const input = document.getElementById('taskInput');
+  let tasks = store.get('tasks', [
+    {text:'Sample task', done:false}
+  ]);
+  function render(){
+    list.innerHTML='';
+    tasks.forEach((t,i)=>{
+      const li=document.createElement('li');
+      li.textContent=t.text;
+      if(t.done) li.style.textDecoration='line-through';
+      li.onclick=()=>{t.done=!t.done;store.set('tasks',tasks);render();notify('Task updated');};
+      list.appendChild(li);
+    });
+  }
+  render();
+  form.onsubmit=e=>{e.preventDefault();tasks.push({text:input.value,done:false});input.value='';store.set('tasks',tasks);render();};
+}

--- a/modules/tasks/view.html
+++ b/modules/tasks/view.html
@@ -1,0 +1,6 @@
+<h2>Tasks</h2>
+<form id="taskForm">
+  <input id="taskInput" placeholder="New task" required />
+  <button>Add</button>
+</form>
+<ul id="taskList"></ul>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,57 @@
+:root {
+  --bg: #fff;
+  --fg: #222;
+  --accent: #4e8cff;
+  --spacing: 1rem;
+}
+
+[data-theme="dark"] {
+  --bg: #1e1e1e;
+  --fg: #eee;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing);
+  background: var(--accent);
+  color: #fff;
+}
+
+nav a {
+  margin-right: var(--spacing);
+  color: #fff;
+  text-decoration: none;
+}
+
+main {
+  flex: 1;
+  padding: var(--spacing);
+  overflow-y: auto;
+}
+
+#palette {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--accent);
+  padding: var(--spacing);
+  width: 300px;
+  max-height: 50vh;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+.hidden { display: none; }

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+const CACHE = 'pos-v1';
+const CORE = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/app.js'
+];
+self.addEventListener('install',e=>{
+  e.waitUntil(caches.open(CACHE).then(c=>c.addAll(CORE)));
+});
+self.addEventListener('activate',e=>{
+  e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k)))));
+});
+self.addEventListener('fetch',e=>{
+  e.respondWith(
+    caches.match(e.request).then(res=>res||fetch(e.request).catch(()=>new Response('Offline',{status:503})))
+  );
+});


### PR DESCRIPTION
## Summary
- scaffold Personal OS student-creator edition web app
- add modular plugins with sample data and AI adapter layer
- include service worker, theme toggle, and settings for API keys

## Testing
- `zip -r personal-os.zip . -x '.git/*' 'personal-os.zip'`


------
https://chatgpt.com/codex/tasks/task_e_68bd333f34948328838f52c65a0dc8f7